### PR TITLE
Replace 200 latencyBuckets to 15 fixed size buckets

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -58,7 +58,11 @@ var (
 	servLabels        = []string{"server"}
 	latencyLabels     = []string{"latency"}
 	servLatencyLabels = []string{"server", "latency"}
-	latencyBuckets    = append(prometheus.LinearBuckets(20, 20, 100), prometheus.ExponentialBuckets(2048., 1.06437, 100)...)
+	// TODO: Instead of using hardcoded bounds, use bounds parsed from redis cli corresponding
+	// to each latency monitor. These bounds are defined in latency.conf which is feeded to
+	// predixy during boot up.
+	latencyBuckets = []float64{100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000,
+		4000, 5000, 6000}
 )
 
 type Exporter struct {


### PR DESCRIPTION
I saw 28k time series being fetched from one instance of predixy_o2 cluster. There could be 300+ instances running at a time.
Last week trend show that maximum of 13M timeseries was fetched at the peak hours at a particular time.

Also, 2.3G of samples were fetched during that 2 hours interval.

Prometheus before persisting the data, store 2 hours worth of time series in memory. During this time, the maximum RSS of the docker container(where this instance was running) was 25GB. If I assume that there could be 5x traffic in the NYE, we at least need a 100GB RAM server to accommodate such traffic.

Another option is to chuck out the irrelevant time series.
Out of 28k time series, 27.5k time-series belongs to histogram metrics type. The Prometheus Best Practices documents state that the maximum cardinality of a metric should be about 10 unique label/value pairs, so as the buckets in each histogram. But this is not the case in predixy metrics.
```
[ec2-user@ip-192-168-95-216 ~]$ cat  metrics| grep "latency=\"SortedSets\",server=\"192.168.5.87:6379\"" | wc
    203     406   28303
```
For a single histogram, 203 buckets are there, 20ms, 40ms, 60ms,...

This fix replace the 200 latency buckets to 15 fixed-size buckets. These 15 bounds are defined in latency.conf which is fed to predixy during boot up. 
https://github.com/Zomato/ansible-scaling-deploy/blob/master/roles/predixy/files/defaults/default.latency.conf

Change in the number of time series per instance:
```
admin@sng-worker48-243:~$ cat original | wc
  13743   28039 1819171
admin@sng-worker48-243:~$ cat new | wc
   1533    3619  157383
```
